### PR TITLE
Fix script count

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,96 +1,136 @@
 "use strict";
-
 // need to load background.js as persistent in manifest.json, otherwise it will be unloaded and these maps will be lost!
 
-/** @type {Map<number, number>} map with number of scripts loaded per tab */
-const scriptsLoadedByTabId = new Map();
-/** @type {Map<number, number>} map with number of stylesheets loaded per tab */
-const stylesLoadedByTabId = new Map();
+/**
+ * Quick doc to help linters
+ * @class chrome
+ * @property runtime.onMessage.addListener
+ * @property tabs.onActivated
+ * @property browserAction.setBadgeText
+ */
 
 /**
- * Ask the local server to retrieve all relevant scripts for this url.
- *
- * @param {{ type: string, hostname: string }} parameters - type is either 'css' or 'js' and hostname is the page's
- * @param {Object} sender - not used
- * @param {Function} callback - will be called back with all scripts bundled into a single string
+ * // https://developer.chrome.com/extensions/tabs#type-Tab
+ * @class Tab
+ * @property {number} id
  */
-function retrieveRelatedScriptsFromServer(parameters, sender, callback) {
-    const httpRequest = new XMLHttpRequest();
-
-    httpRequest.addEventListener('readystatechange', () => {
-        if (httpRequest.readyState === XMLHttpRequest.DONE) {
-            parseScriptResponse(httpRequest.status, httpRequest.responseText, parameters, sender, callback);
-        }
-    });
-
-    const SVR_PROTOCOL = 'http';
-    const SVR_HOSTNAME = 'localhost';
-    const SVR_PORT = 3131;
-
-    // composes a request to our local server (e.g.: http://localhost:3131/css/github.com)
-    const requestUrl = `${SVR_PROTOCOL}://${SVR_HOSTNAME}:${SVR_PORT}/${parameters.type}/${parameters.hostname}`;
-
-    httpRequest.open('GET', requestUrl);
-    httpRequest.send();
-
-    return true;  // must return true to indicate to our peer that it should keep listening for an asynchronous response
-                  // thanks to https://stackoverflow.com/a/20077854/778272
-}
 
 /**
- * Process incoming server response with scripts to inject in the foreground.
- *
- * @param {number} status - 200 if response is good; something else otherwise
- * @param {string} responseText - the contents returned by the local server
- * @param {{ type: string, hostname: string }} parameters - the parameters passed by the foreground script
- * @param {{ tab: {id: number} }} sender - the sender context of the foreground script
- * @param {Function} callback - function to call back to send script to the foreground
+ * // https://developer.chrome.com/extensions/runtime#type-MessageSender
+ * @class MessageSender
+ * @property {Tab} tab
+ * @property {number} frameId
  */
-function parseScriptResponse(status, responseText, parameters, sender, callback) {
-    let script = '';
-    let scriptCount = 0;
 
-    // if we did get valid content
-    if (status === 200) {
-        script = responseText;
 
-        // retrieve from the response the number of scripts found
-        const re = /^(\d+)/g;  // global flag so we have access to lastIndex after the match
-        const scriptCountMatch = re.exec(script);
-        if (scriptCountMatch) {
-            scriptCount = parseInt(scriptCountMatch[1], 10);
-            script = script.substring(re.lastIndex);  // remove scripts count from final script
-        }
+class WitchcraftBackgroundManager {
+
+    constructor () {
+        /** @type {Map<number, Set<string>>} map with number of scripts loaded per tab */
+        this.scriptsLoadedByTabId = new Map();
+
+        // listen for script/stylesheet requests
+        chrome.runtime.onMessage.addListener(this.retrieveRelatedScriptsFromServer.bind(this));
+
+        // listen for tab switches
+        chrome.tabs.onActivated.addListener(
+            /** @type {{tabId: number}} */ activeInfo => this.updateIconBadge(activeInfo.tabId));
     }
 
-    // send the script to the foreground
-    callback(script);
-
-    const tabId = sender.tab.id;
-
-    if (parameters.type === 'js') {
-        scriptsLoadedByTabId.set(tabId, scriptCount);
-    } else if (parameters.type === 'css') {
-        stylesLoadedByTabId.set(tabId, scriptCount);
+    createOrResetScriptsSetForTab(tabId) {
+        let scripts = this.scriptsLoadedByTabId.get(tabId);
+        if (!scripts) {
+            scripts = new Set();
+            this.scriptsLoadedByTabId.set(tabId, scripts);
+        } else {
+            scripts.clear();
+        }
+        return scripts;
     }
 
-    updateIconBadge(tabId);
+    /**
+     * Ask the local server to retrieve all relevant scripts for this url.
+     *
+     * @param {{ type: string, hostname: string }} parameters - type is either 'css' or 'js' and hostname is the page's
+     * @param {MessageSender} sender - the sender context of the foreground script
+     * @param {Function} callback - will be called back with all scripts bundled into a single string
+     */
+    retrieveRelatedScriptsFromServer(parameters, sender, callback) {
+
+        let scriptsSet = null;
+        if (sender.frameId === 0) {
+            // this is the top frame of the tab, so take the chance and reset the set of scripts for that tab
+            scriptsSet = this.createOrResetScriptsSetForTab(sender.tab.id);
+        } else {
+            scriptsSet = this.scriptsLoadedByTabId.get(sender.tab.id);
+        }
+
+        const httpRequest = new XMLHttpRequest();
+
+        httpRequest.addEventListener('readystatechange', () => {
+            if (httpRequest.readyState === XMLHttpRequest.DONE) {
+                this.parseScriptResponse(
+                    httpRequest.status, httpRequest.responseText, sender.tab.id, scriptsSet, callback);
+            }
+        });
+
+        const SVR_PROTOCOL = 'http';
+        const SVR_HOSTNAME = 'localhost';
+        const SVR_PORT = 3131;
+
+        // composes a request to our local server (e.g.: http://localhost:3131/css/github.com)
+        const requestUrl = `${SVR_PROTOCOL}://${SVR_HOSTNAME}:${SVR_PORT}/${parameters.type}/${parameters.hostname}`;
+
+        httpRequest.open('GET', requestUrl);
+        httpRequest.send();
+
+        return true;  // must return true to indicate to our peer that it should keep listening for an asynchronous response
+                      // thanks to https://stackoverflow.com/a/20077854/778272
+    }
+
+    /**
+     * Process incoming server response with scripts to inject in the foreground.
+     *
+     * @param {number} status - 200 if response is good; something else otherwise
+     * @param {string} responseText - the contents returned by the local server
+     * @param {number} tabId - tab being updated
+     * @param {Set<string>} scriptsSet - the set of scripts loaded by the current tab so far
+     * @param {Function} callback - function to call back to send script to the foreground
+     */
+    parseScriptResponse(status, responseText, tabId, scriptsSet, callback) {
+        let script = '';
+
+        // if we did get valid content
+        if (status === 200) {
+            script = responseText;
+
+            const scriptStartIndex = script.indexOf('\n\n');
+            if (scriptStartIndex !== -1) {
+                script.substring(0, scriptStartIndex).split('\n').forEach(scriptName => scriptsSet.add(scriptName));
+
+                // skip script names before sending final result to the foreground
+                script = script.substring(scriptStartIndex);
+            }
+        }
+
+        // send the script to the foreground
+        callback(script);
+
+        console.info(`[${tabId}] scripts loaded so far: ${[...scriptsSet.keys()]}`);
+
+        this.updateIconBadge(tabId);
+    }
+
+    /**
+     * Update the icon badge with the number of scripts loaded by the currently active Chrome tab.
+     *
+     * @param {number} tabId - the id of the tab for which the badge should reflect the number of scripts loaded
+     */
+    updateIconBadge(tabId) {
+        const scripts = this.scriptsLoadedByTabId.get(tabId);
+        const countStr = scripts ? scripts.size.toString() : '';
+        chrome.browserAction.setBadgeText({ text: countStr });
+    }
 }
 
-/**
- * Update the icon badge with the number of scripts loaded by the currently active Chrome tab.
- *
- * @param {number} tabId - the id of the tab for which the badge should reflect the number of scripts loaded
- */
-function updateIconBadge(tabId) {
-    const scriptsCount = scriptsLoadedByTabId.get(tabId) || 0;
-    const stylesCount = stylesLoadedByTabId.get(tabId) || 0;
-    const totalCount = scriptsCount + stylesCount;
-    chrome.browserAction.setBadgeText({text: totalCount > 0 ? totalCount.toString() : ''});
-}
-
-// listen for script/stylesheet requests
-chrome.runtime.onMessage.addListener(retrieveRelatedScriptsFromServer);
-
-// listen for tab switches
-chrome.tabs.onActivated.addListener(activeInfo => updateIconBadge(activeInfo.tabId));
+new WitchcraftBackgroundManager();

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -2,7 +2,7 @@
   "name": "Witchcraft: Inject JS and CSS",
   "short_name": "Witchcraft",
   "manifest_version": 2,
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Inject Javascript and CSS right from your home folder. It's GreaseMonkey for developers!",
   "icons": {
     "16": "witch-16.png",

--- a/witchcraft.js
+++ b/witchcraft.js
@@ -55,24 +55,29 @@ class WitchcraftServer {
             WitchcraftServer.log(`Received request for "${request.url}"`);
             if (this.visitedScripts.size === 0) {
                 WitchcraftServer.log('\tNo scripts found');
+                WitchcraftServer.sendEmptyResponse(response);
             } else {
                 WitchcraftServer.log('\tScripts found:');
+
                 for (const script of this.visitedScripts.keys()) {
                     WitchcraftServer.log('\t* ' + script);
                 }
+
+                const scriptNames = [...this.visitedScripts.keys()].join('\n');
+                response.writeHead(200, { 'Content-Type': requestOptions.fileTypeOptions.mimeType });
+                response.end(`${scriptNames}\n\n${resultingScript}`);
             }
-
-            const scriptCount = this.visitedScripts.size;
-
-            response.writeHead(200, { 'Content-Type': requestOptions.fileTypeOptions.mimeType });
-            response.end(`${scriptCount}\n${resultingScript}`);
         } else {
             WitchcraftServer.log(`Invalid request "${request.url}"`);
 
             // we always return success, no matter what; we don't want to pollute Chrome's console with errors
-            response.writeHead(200, { 'Content-Type': 'text/plain' });
-            response.end('0');  // signal that no scripts (hence the "0") were found
+            WitchcraftServer.sendEmptyResponse(response);
         }
+    }
+
+    static sendEmptyResponse(response) {
+        response.writeHead(200, { 'Content-Type': 'text/plain' });
+        response.end('');  // signal that no scripts (hence the "0") were found
     }
 
     /**


### PR DESCRIPTION
My approach ended up being different from what was proposed on #1. I decided to, instead of storing the script count, storing script names in a set instead. That way the script can just add new script names to the set and, in case they were already loaded by another frame in the same tab, we still won't count them more than once. The second necessary change is to clear that set whenever a new request for frameId 0 (i.e., the top frame on that tab) is made. This way we can know when a page refresh is taking place, so we can invalidate the previous set of script names and the count will always be consistent.