### PR TITLE
Prevent caching

### DIFF
--- a/chrome-extension/witchcraft.js
+++ b/chrome-extension/witchcraft.js
@@ -127,7 +127,7 @@ class Witchcraft {
     async queryServerForFile(scriptFileName, scriptType) {
         try {
             const fullUrl = this.fullUrlRegex.test(scriptFileName) ? scriptFileName : this.serverAddress + scriptFileName;
-            const response = await this.fetch(fullUrl);
+            const response = await this.fetch(fullUrl, {cache: "no-store"});
             this.isServerReachable = true;
 
             if (response.status === 200) {

--- a/chrome-extension/witchcraft.js
+++ b/chrome-extension/witchcraft.js
@@ -67,6 +67,7 @@ class Witchcraft {
 
         // fetch is only undefined during tests
         this.fetch = typeof fetch === "undefined" ? (async () => {}) : fetch.bind(window);
+        this.fetchOptions = { cache: "no-store" };
 
         // either `// @include foo.js` or `/* @include foo.js */`
         this.includeDirectiveRegexJs = /^[ \t]*(?:\/\/|\/\*)[ \t]*@include[ \t]*(".*?"|[^*\s]+).*$/mg;
@@ -127,7 +128,7 @@ class Witchcraft {
     async queryServerForFile(scriptFileName, scriptType) {
         try {
             const fullUrl = this.fullUrlRegex.test(scriptFileName) ? scriptFileName : this.serverAddress + scriptFileName;
-            const response = await this.fetch(fullUrl, {cache: "no-store"});
+            const response = await this.fetch(fullUrl, this.fetchOptions);
             this.isServerReachable = true;
 
             if (response.status === 200) {

--- a/test/witchcraft.js
+++ b/test/witchcraft.js
@@ -239,7 +239,8 @@ describe("Witchcraft", function () {
         const localFile = "google.com.js";
         await witchcraft.queryServerForFile(localFile, Witchcraft.EXT_JS);
         assert(witchcraft.fetch.calledOnce);
-        assert(witchcraft.fetch.getCall(0).calledWithExactly(witchcraft.serverAddress + localFile));
+        assert(witchcraft.fetch.getCall(0)
+            .calledWithExactly(witchcraft.serverAddress + localFile, witchcraft.fetchOptions));
     });
 
     it("should handle remote URL", async function () {
@@ -250,7 +251,7 @@ describe("Witchcraft", function () {
         const url = "https://google.com/foo.js";
         await witchcraft.queryServerForFile(url, Witchcraft.EXT_JS);
         assert(witchcraft.fetch.calledOnce);
-        assert(witchcraft.fetch.getCall(0).calledWithExactly(url));
+        assert(witchcraft.fetch.getCall(0).calledWithExactly(url, witchcraft.fetchOptions));
     });
 
     it("should correctly match JavaScript include directives", function () {


### PR DESCRIPTION
This is essentially #36, but with tests fixed.

Thanks @shihshen for taking the time to investigate and share your fix. I never had caching problems with Web Server for Chrome, but it may definitely may help others using different web servers to serve the scripts.