### PR TITLE
Check for path-matches under _global

### DIFF
--- a/chrome-extension/path/generate-potential-script-names.js
+++ b/chrome-extension/path/generate-potential-script-names.js
@@ -13,6 +13,7 @@ export function generatePotentialScriptNames(url) {
     const paths = Array.from(iteratePathSegments(pathName));
     if (paths.length > 0) {
         result.push(...paths.map(path => hostName + path))
+        result.push(...paths.map(path => GLOBAL_SCRIPT_NAME + path))
     }
     return result;
 }

--- a/test/path/generate-potential-script-names.js
+++ b/test/path/generate-potential-script-names.js
@@ -23,6 +23,9 @@ describe("Script name generator", function () {
             "www.luciopaiva.com/foo",
             "www.luciopaiva.com/foo/bar",
             "www.luciopaiva.com/foo/bar/index.html",
+            `${GLOBAL_SCRIPT_NAME}/foo`,
+            `${GLOBAL_SCRIPT_NAME}/foo/bar`,
+            `${GLOBAL_SCRIPT_NAME}/foo/bar/index.html`,
         ]);
     });
 


### PR DESCRIPTION
There's a Wordpress plugin (I think) for recipes that always puts the printer-friendly view under `/wprm_print`.

This PR should let me keep one copy of `_global/wprm_print.css` instead of needing to make another @include file for _every single blog_ that has a recipe I want to print.

(I haven't tested it locally yet, I'll do that today, but I'm making the PR now because I saw your comment on #64 about preparing a release soon)